### PR TITLE
Use psycopg2-binary instead to avoid build from source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 geopandas==0.4.0
 sqlalchemy==1.2.11
-psycopg2==2.7.5
+psycopg2-binary==2.8.4
 geoalchemy2==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name='geopandas-postgis',
     version='0.1.1',
     packages=['geopandas_postgis', 'geopandas_postgis.tests'],
-    install_requires=['SQLAlchemy', 'GeoAlchemy2', 'geopandas', 'psycopg2'],
+    install_requires=['SQLAlchemy', 'GeoAlchemy2', 'geopandas', 'psycopg2-binary'],
     url='',
     license='MIT License',
     author='Aaron Burgess',


### PR DESCRIPTION
Changing psycopg2 to psycopg2-binary to avoid the need to build from the source. Building from source requires pg_config -which may require to install Postgres- which may not be needed. 